### PR TITLE
Add missing step to README.md for first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Make sure you have [Go](http://golang.org/doc/install) and the [Heroku Toolbelt]
 ```sh
 $ go get -u github.com/heroku/go-getting-started
 $ cd $GOPATH/src/github.com/heroku/go-getting-started
+$ go build
 $ heroku local
 ```
 


### PR DESCRIPTION
Attempted to follow steps exactly. Most familiar with Go will probably not run into this, but since this is a getting started project it's probably good to be thorough. Platform experienced on is Windows.

```PS C:\Users\Mollrow> cd .\go\
PS C:\Users\Mollrow\go> go get -u github.com/heroku/go-getting-started
PS C:\Users\Mollrow\go> cd .\src\github.com\heroku\go-getting-started\
PS C:\Users\Mollrow\go\src\github.com\heroku\go-getting-started> heroku local
[OKAY] Loaded ENV .env File as KEY=VALUE Format
10:31:57 AM web.1 |  'go-getting-started' is not recognized as an internal or external command,
10:31:57 AM web.1 |  operable program or batch file.
10:31:57 AM web.1 Exited with exit code 1
PS C:\Users\Mollrow\go\src\github.com\heroku\go-getting-started> go build
PS C:\Users\Mollrow\go\src\github.com\heroku\go-getting-started> heroku local
[OKAY] Loaded ENV .env File as KEY=VALUE Format
10:32:16 AM web.1 |  [GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
10:32:16 AM web.1 |   - using env:      export GIN_MODE=release
10:32:16 AM web.1 |   - using code:     gin.SetMode(gin.ReleaseMode)
10:32:16 AM web.1 |  [GIN-debug] GET   /static/*filepath         --> github.com/heroku/go-getting-started/vendor/github.
com/gin-gonic/gin.(*RouterGroup).createStaticHandler.func1 (2 handlers)
10:32:16 AM web.1 |  [GIN-debug] HEAD  /static/*filepath         --> github.com/heroku/go-getting-started/vendor/github.
com/gin-gonic/gin.(*RouterGroup).createStaticHandler.func1 (2 handlers)
10:32:16 AM web.1 |  [GIN-debug] GET   /                         --> main.main.func1 (2 handlers)
10:32:16 AM web.1 |  [GIN-debug] Listening and serving HTTP on :5000```