### PR TITLE
Set goversion example for buildpack on Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/heroku/go-getting-started
 
+// +heroku goVersion go1.12
 go 1.12
 
 require (


### PR DESCRIPTION
### Change
Adds an example on how to define the `goVersion` on Go modules.
The definition is documented on https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-go
This example will save some time for developers who may found an error like:
```
Step 6/13 : RUN STACK=heroku-18 /tmp/buildpack/heroku/go/bin/compile /app /tmp/build_cache /tmp/env
 ---> Running in 8d4e250a395f
-----> Fetching jq... done
-----> Fetching stdlib.sh.v8... done
----->
       Detected go modules via go.mod
----->
       Detected Module Name: github.com/myuser/my-awesome-project
----->
 !!    The go.mod file for this project does not specify a Go version
 !!
 !!    Defaulting to go1.12.17
 !!
 !!    For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration
 !!
-----> New Go Version, clearing old cache
```