### PR TITLE
Remove usage of legacy codon-buildpacks buildpack URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM heroku/heroku:18-build as build
+FROM heroku/heroku:20-build as build
 
 COPY . /app
 WORKDIR /app
 
 # Setup buildpack
 RUN mkdir -p /tmp/buildpack/heroku/go /tmp/build_cache /tmp/env
-RUN curl https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/go.tgz | tar xz -C /tmp/buildpack/heroku/go
+RUN curl https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/go.tgz | tar xz -C /tmp/buildpack/heroku/go
 
 #Execute Buildpack
-RUN STACK=heroku-18 /tmp/buildpack/heroku/go/bin/compile /app /tmp/build_cache /tmp/env
+RUN STACK=heroku-20 /tmp/buildpack/heroku/go/bin/compile /app /tmp/build_cache /tmp/env
 
 # Prepare final, minimal image
-FROM heroku/heroku:18
+FROM heroku/heroku:20
 
 COPY --from=build /app /app
 ENV HOME /app


### PR DESCRIPTION
The `codon-buildpacks` S3 bucket has been deprecated for many years, having been replaced by the buildpack registry shorthand aliases, which map to the `buildpack-registry` S3 bucket instead.

New buildpack releases are currently backported to the legacy `codon-buildpacks` bucket from `buildpack-registry` by a sync job (so this PR has no change on functionality), however that job will be sunset soon, causing `codon-buildpacks` to become stale.

In addition, the stack used by the `Dockerfile` has been updated from Heroku-18 to Heroku-20.

GUS-W-10034067.