### PR TITLE
readme changes for efp. do not merge until 11/28

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Your app should now be running on [localhost:5000](http://localhost:5000/).
 
 ## Deploying to Heroku
 
+Using resources for this example app counts towards your usage. [Delete your app](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-apps-destroy) and [database](https://devcenter.heroku.com/articles/heroku-postgresql#removing-the-add-on) as soon as you are done experimenting to control costs.
+
+By default, apps use Eco dynos if you are subscribed to Eco. Otherwise, it defaults to Basic dynos. The Eco dynos plan is shared across all Eco dynos in your account and is recommended if you plan on deploying many small apps to Heroku. Learn more about our low-cost plans [here](https://blog.heroku.com/new-low-cost-plans).
+
+Eligible students can apply for platform credits through our new [Heroku for GitHub Students program](https://blog.heroku.com/github-student-developer-program).
+
 ```sh
 $ heroku create
 $ git push heroku main


### PR DESCRIPTION
Once Heroku's free plans end, creating apps for the tutorial will count towards account Eco hours/credits/charges usage, so this needs to be made clear in the README.

This should not be merged until 28th November, when the plan changes take effect.

[GUS-W-12008817](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12008817).