### PR TITLE
Don't hardcode the binary path in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/go-getting-started
+web: go-getting-started


### PR DESCRIPTION
The bin/ prefix is not compatible with the [Go CNB](heroku/buildpacks-go), which installs binaries to a location outside of the app directory. The classic buildpack adds `<app_dir>/bin` to the `$PATH`, so the `bin/` prefix is unneccessary.

This change is driven by the conversation here: https://github.com/heroku/builder/pull/302#issuecomment-1338269066