### PR TITLE
Fix GUSINFO metadata in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 
 # Default to requesting pull request reviews from the Heroku Languages team.
 #ECCN:Open Source
-#GUSINFO:Languages,Heroku Go Platform
+#GUSINFO:Heroku - Languages,Heroku Go Platform
 * @heroku/languages

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .env
 .docker_build/
 bin/


### PR DESCRIPTION
Since the Languages team was renamed to `Heroku - Languages` in GUS some time ago.

GUS-W-21708465.